### PR TITLE
update to scalajs 1.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import Options._
 
-
 inThisBuild(Seq(
   version := "0.1.0-SNAPSHOT",
 
@@ -12,18 +11,18 @@ inThisBuild(Seq(
 
   licenses += ("Apache 2", url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
 
-  homepage := Some(url("https://outwatch.github.io/")),
+	  homepage := Some(url("https://outwatch.github.io/")),
 
-  scmInfo := Some(ScmInfo(
-    url("https://github.com/OutWatch/outwatch-libs"),
-    "scm:git:git@github.com:OutWatch/outwatch-libs.git",
-    Some("scm:git:git@github.com:OutWatch/outwatch-libs.git"))
-  )
-))
+		  scmInfo := Some(ScmInfo(
+			  url("https://github.com/OutWatch/outwatch-libs"),
+				  "scm:git:git@github.com:OutWatch/outwatch-libs.git",
+				  Some("scm:git:git@github.com:OutWatch/outwatch-libs.git"))
+			  )
+		  ))
 
 lazy val commonSettings = Seq(
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
-  addCompilerPlugin("com.github.ghik" % "silencer-plugin" % "1.6.0" cross CrossVersion.full),
+	addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
+	addCompilerPlugin("com.github.ghik" % "silencer-plugin" % "1.6.0" cross CrossVersion.full),
 
   useYarn := true,
 
@@ -32,15 +31,17 @@ lazy val commonSettings = Seq(
     Nil,
 
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest" % "3.1.1" % Test,
+    "org.scalatest" %%% "scalatest" % "3.2.0" % Test,
     "com.github.ghik" % "silencer-lib" % "1.6.0" % Provided cross CrossVersion.full,
-    "com.github.outwatch.outwatch" %%% "outwatch" % "f3a15f2b"
+    "com.github.outwatch.outwatch" %%% "outwatch" % "61deece"		//"f3a15f2b" original
   ),
 
   scalacOptions ++= CrossVersion.partialVersion(scalaVersion.value).map(v =>
     allOptionsForVersion(s"${v._1}.${v._2}", true)
   ).getOrElse(Nil),
-  scalacOptions in (Compile, console) ~= (_.diff(badConsoleFlags))
+
+  scalacOptions in (Compile, console) ~= (_.diff(badConsoleFlags)),
+
 )
 
 lazy val librarySettings = commonSettings ++ Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -11,14 +11,14 @@ inThisBuild(Seq(
 
   licenses += ("Apache 2", url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
 
-	  homepage := Some(url("https://outwatch.github.io/")),
+  homepage := Some(url("https://outwatch.github.io/")),
 
-		  scmInfo := Some(ScmInfo(
-			  url("https://github.com/OutWatch/outwatch-libs"),
-				  "scm:git:git@github.com:OutWatch/outwatch-libs.git",
-				  Some("scm:git:git@github.com:OutWatch/outwatch-libs.git"))
-			  )
-		  ))
+  scmInfo := Some(ScmInfo(
+    url("https://github.com/OutWatch/outwatch-libs"),
+    "scm:git:git@github.com:OutWatch/outwatch-libs.git",
+    Some("scm:git:git@github.com:OutWatch/outwatch-libs.git"))
+  )
+))
 
 lazy val commonSettings = Seq(
 	addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
@@ -33,7 +33,7 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.scalatest" %%% "scalatest" % "3.2.0" % Test,
     "com.github.ghik" % "silencer-lib" % "1.6.0" % Provided cross CrossVersion.full,
-    "com.github.outwatch.outwatch" %%% "outwatch" % "61deece"		//"f3a15f2b" original
+    "com.github.outwatch.outwatch" %%% "outwatch" % "61deece"
   ),
 
   scalacOptions ++= CrossVersion.partialVersion(scalaVersion.value).map(v =>

--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,8 @@ inThisBuild(Seq(
 ))
 
 lazy val commonSettings = Seq(
-	addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
-	addCompilerPlugin("com.github.ghik" % "silencer-plugin" % "1.6.0" cross CrossVersion.full),
+  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
+  addCompilerPlugin("com.github.ghik" % "silencer-plugin" % "1.6.0" cross CrossVersion.full),
 
   useYarn := true,
 

--- a/hammerjs/src/main/scala/outwatch/libs/hammerjs/facade/Hammer.scala
+++ b/hammerjs/src/main/scala/outwatch/libs/hammerjs/facade/Hammer.scala
@@ -41,7 +41,6 @@ trait PropagatedHammer extends Hammer[PropagatingEvent] {
 // Hammer.js does not natively support event propagation. This wrapper fixes it.
 // https://github.com/hammerjs/hammer.js/issues/807
 // https://github.com/josdejong/propagating-hammerjs
-//@js.native
 @JSImport("propagating-hammerjs", JSImport.Namespace)
 @js.native
 object propagating extends js.Function1[Hammer[Event], PropagatedHammer] {

--- a/hammerjs/src/main/scala/outwatch/libs/hammerjs/facade/Hammer.scala
+++ b/hammerjs/src/main/scala/outwatch/libs/hammerjs/facade/Hammer.scala
@@ -41,9 +41,11 @@ trait PropagatedHammer extends Hammer[PropagatingEvent] {
 // Hammer.js does not natively support event propagation. This wrapper fixes it.
 // https://github.com/hammerjs/hammer.js/issues/807
 // https://github.com/josdejong/propagating-hammerjs
-@js.native
+//@js.native
 @JSImport("propagating-hammerjs", JSImport.Namespace)
+@js.native
 object propagating extends js.Function1[Hammer[Event], PropagatedHammer] {
+  @JSName("apply")
   override def apply(arg1: Hammer[Event]): PropagatedHammer = js.native
 }
 

--- a/project/Options.scala
+++ b/project/Options.scala
@@ -79,9 +79,7 @@ object Options {
     "2.11" -> options211,
   )
 
-  val scalajsOptions = Seq(
-    "-P:scalajs:sjsDefinedByDefault",
-  )
+  val scalajsOptions = Nil
 
   def allOptionsForVersion(v: String, js: Boolean): Seq[String] =
     versionBasedOptions.getOrElse(v, Nil) ++ (if(js) scalajsOptions else Nil)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.8
+sbt.version = 1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,8 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler-sjs06" % "0.17.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.1")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.18.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")


### PR DESCRIPTION
I am updating the library to scalajs 1.1.1
because I need it for my app.

this is one of my first tries on github.

Sorry if I am doing wrong, I will try to make it better if something bad happens.

I am not sure if the pull request was made by the way. :P

but in my local the lib is working with scalajs 1.1.1